### PR TITLE
Fix: sed: -e expression #1, char 91: unterminated `s' command

### DIFF
--- a/sender.sh
+++ b/sender.sh
@@ -47,7 +47,7 @@ function sendMail() {
         FILENAME="Message.txt"
     else
         FILENAME=$(basename "${ATTACHMENT%}")
-        ATTACHMENT=`base64 -i $ATTACHMENT`
+        ATTACHMENT=`base64 -i -w 0 $ATTACHMENT`
     fi
 
     TEMPLATE="ses-email-template.json"


### PR DESCRIPTION
**Problem:**
I was trying to execute the following command:

sh ses_emailer.sh --subject "This is a sample email from pigeon server" --from "support@mydomain.com" --receiver "myemail@mydomain.com" --body "ses says hi" --attachment /var/www/sites/error_20200302.txt

Hence receiving the error sed: -e expression #1, char 91: unterminated s' commandonce I am adding--attachment /var/www/sites/error_20200302.txt`

**Solution:**
Added `base64 -w 0` 

> Wrap encoded lines after COLS character (default 76). Use 0 to disable line wrapping.

`ATTACHMENT=`base64 -i -w 0 $ATTACHMENT``