### PR TITLE
Fixes sed on OSX issue

### DIFF
--- a/sender.sh
+++ b/sender.sh
@@ -7,6 +7,16 @@
 
 ## Global vars
 
+
+shopt -s expand_aliases
+
+# set the default sed behavior to do a replace with bo backup
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  alias sedCmd="sed -i ''"
+else
+  alias sedCmd="sed -i "
+fi
+
 function usage() {
     echo "Usage: $0 [-h|--help ]
         [-s|--subject <string> subject/title for email ]
@@ -56,12 +66,12 @@ function sendMail() {
 
     cp $TEMPLATE $TMPFILE
 
-    sed -i -e "s/{SUBJECT}/$SUBJECT/g" $TMPFILE
-    sed -i -e "s/{FROM}/$FROM/g" $TMPFILE
-    sed -i -e "s/{RECVS}/$RECVS/g" $TMPFILE
-    sed -i -e "s/{BODY}/$BODY/g" $TMPFILE
-    sed -i -e "s/{FILENAME}/$FILENAME/g" $TMPFILE
-    sed -i -e "s/{ATTACHMENT}/$ATTACHMENT/g" $TMPFILE
+    sedCmd -e "s/{SUBJECT}/$SUBJECT/g" $TMPFILE
+    sedCmd -e "s/{FROM}/$FROM/g" $TMPFILE
+    sedCmd -e "s/{RECVS}/$RECVS/g" $TMPFILE
+    sedCmd -e "s/{BODY}/$BODY/g" $TMPFILE
+    sedCmd -e "s/{FILENAME}/$FILENAME/g" $TMPFILE
+    sedCmd -e "s/{ATTACHMENT}/$ATTACHMENT/g" $TMPFILE
 
     aws ses send-raw-email --raw-message file://$TMPFILE
 }
@@ -109,6 +119,7 @@ while :; do
 
   shift
 done
+
 
 checkRequirements
 


### PR DESCRIPTION
I noticed when running the script an odd behavior on OSX.  It would create multiple temp files.  e.g.

```
-rw-r--r-- 1 harsch 441 Mar  9 17:46 /tmp/ses-1615340802-e
-rw-r--r-- 1 harsch 449 Mar  9 17:46 /tmp/ses-1615340802
```

I then noticed that the script uses an unsafe form for sed.

This PR fixes sed to work on OSX as well as non-OSX platforms.